### PR TITLE
added interfaces and knnclassifier

### DIFF
--- a/src/main/java/knnclassifier/Classifier.java
+++ b/src/main/java/knnclassifier/Classifier.java
@@ -1,0 +1,18 @@
+
+package tletters.knnclassifier;
+
+import java.util.Collection;
+
+/**
+ *
+ * @author Piotr
+ * @param <VAL>
+ * @param <FV>
+ * @param <DST>
+ */
+public interface Classifier <VAL extends Number, DST extends DistanceMeter<VAL> >
+{
+	public  void fit( Collection< Collection<VAL> > descriptions, Collection<Integer> classes, DST distancemeter );
+	
+	public Integer predict( Collection<VAL> description );
+}

--- a/src/main/java/knnclassifier/DistanceMeter.java
+++ b/src/main/java/knnclassifier/DistanceMeter.java
@@ -1,0 +1,14 @@
+
+package tletters.knnclassifier;
+
+import java.util.Collection;
+
+/**
+ *
+ * @author Piotr
+ * @param <VAL>
+ */
+public interface  DistanceMeter <VAL extends Number>
+{
+	public  double distance( Collection<VAL> lhs, Collection<VAL> rhs );
+}

--- a/src/main/java/knnclassifier/EuclideanDistanceMeter.java
+++ b/src/main/java/knnclassifier/EuclideanDistanceMeter.java
@@ -1,0 +1,31 @@
+
+package tletters.knnclassifier;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ *
+ * @author Piotr
+ */
+public class EuclideanDistanceMeter <VAL extends Number> implements DistanceMeter <VAL>
+{
+
+	@Override
+	public double distance(Collection<VAL> lhs, Collection<VAL> rhs)
+	{
+		Iterator<VAL> it_lhs =  lhs.iterator();
+		Iterator<VAL> it_rhs =  rhs.iterator();
+		double result = 0.0;
+		double diff;
+		while( it_lhs.hasNext() && it_rhs.hasNext() )
+		{
+			diff = it_lhs.next().doubleValue() - it_rhs.next().doubleValue();
+			result += diff*diff;
+		}
+//		becouse of the fact that distances are only compared to each other in knn algorithm we can omit commputing sqrt
+//		return Math.sqrt(result);
+		return result;
+	}
+	
+}

--- a/src/main/java/knnclassifier/KNNClassifier.java
+++ b/src/main/java/knnclassifier/KNNClassifier.java
@@ -1,0 +1,110 @@
+
+package tletters.knnclassifier;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ *
+ * @author Piotr
+ * @param <VAL>
+ */
+public class KNNClassifier <VAL  extends Number> 
+implements Classifier <VAL, DistanceMeter<VAL> >
+{	
+	
+	private Collection<Collection<VAL>> m_descriptions;
+	Collection<Integer> m_classes;
+	private DistanceMeter<VAL> m_distancemeter;
+	private int m_K;
+	
+	public KNNClassifier( int K )
+	{
+		m_K = K;
+	}
+
+	@Override
+	public void fit(Collection<Collection<VAL>> descriptions, 
+		Collection<Integer> classes, DistanceMeter<VAL> distancemeter)
+	{
+		m_descriptions = descriptions;
+		m_classes = classes;
+		m_distancemeter = distancemeter;
+	}
+
+
+	@Override
+	public Integer predict(Collection<VAL> description)
+	{
+		SortedSet<Pair> neighbours = new TreeSet<>( 
+		(Pair o1, Pair o2)->o1.distance.compareTo(o2.distance) );
+		
+		Iterator< Collection<VAL> > it_fv = m_descriptions.iterator();
+		Iterator< Integer > it_class = m_classes.iterator();
+		
+		double dist;
+		int objclass;
+		while( it_fv.hasNext() && it_class.hasNext() )
+		{
+			dist = m_distancemeter.distance(description, it_fv.next() );
+			objclass = it_class.next();
+			
+			if( neighbours.size() < m_K)
+			{
+				neighbours.add( new Pair(dist, objclass) );
+			}
+			else if( dist < neighbours.last().distance )
+			{
+				neighbours.add( new Pair(dist, objclass) );
+				
+				//can be ommited, but it changes complexity from O(n*logn) to O(n*logK)
+				neighbours.remove( neighbours.last() );
+			}
+		}
+		
+		// count classes 
+		HashMap<Integer, int[]> classCounter = new HashMap<>();
+		for( Pair p : neighbours)
+		{
+			int[] valueWrapper = classCounter.get(p.objclass);
+			if (valueWrapper == null) 
+			{
+				classCounter.put(p.objclass, new int[] { 1 });
+			} else 
+			{
+				valueWrapper[0]++;
+			}
+		}
+		
+		// find most common class
+		int maxCount = 1;
+		int commonClass = neighbours.first().objclass;
+		for( Pair p : neighbours)
+		{
+			int[] valueWrapper = classCounter.get(p.objclass);
+			if ( valueWrapper[0] > maxCount )
+			{
+				maxCount = valueWrapper[0];
+				commonClass = p.objclass;
+			}
+		}
+		
+		// might be different due to solving cases of equal number of neighbour classes
+		return commonClass;
+	}
+	
+	private class Pair
+	{
+		public Double distance;
+		public int objclass;
+		public Pair( double dist, int objcl)
+		{
+			this.distance = dist;
+			this.objclass = objcl;
+		}
+	};
+
+}

--- a/src/test/java/knnclassifier/EuclideanDistanceMeterTest.java
+++ b/src/test/java/knnclassifier/EuclideanDistanceMeterTest.java
@@ -1,0 +1,78 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tletters.knnclassifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Piotr
+ */
+public class EuclideanDistanceMeterTest
+{
+	
+	public EuclideanDistanceMeterTest()
+	{
+	}
+	
+	@BeforeClass
+	public static void setUpClass()
+	{
+	}
+	
+	@AfterClass
+	public static void tearDownClass()
+	{
+	}
+	
+	@Before
+	public void setUp()
+	{
+	}
+	
+	@After
+	public void tearDown()
+	{
+	}
+
+	/**
+	 * Test of distance method, of class EuclideanDistanceMeter.
+	 */
+	@Test
+	public void testDistance()
+	{
+		System.out.println("distance test");
+		{
+			DistanceMeter instance = new EuclideanDistanceMeter();
+			double expResult = 0.0;
+			Double[] fv = {1.,2.,3.};
+			ArrayList<Double> fvArr = new ArrayList<>( Arrays.asList(fv) );
+			Double[] fv2 = {1.,2.,3.};
+			ArrayList<Double> fvArr2 = new ArrayList<>( Arrays.asList(fv2) );
+			double result = instance.distance(fvArr,fvArr2);
+			assertEquals(expResult, result, 1e-10);
+		}
+		
+		{
+			DistanceMeter instance = new EuclideanDistanceMeter();
+			double expResult = 40.0;
+			Double[] fv = {-1.,2.,-3.};
+			ArrayList<Double> fvArr = new ArrayList<>( Arrays.asList(fv) );
+			Double[] fv2 = {1.,2.,3.};
+			ArrayList<Double> fvArr2 = new ArrayList<>( Arrays.asList(fv2) );
+			double result = instance.distance(fvArr,fvArr2);
+			assertEquals(expResult, result, 1e-10);
+		}
+	}
+	
+}

--- a/src/test/java/knnclassifier/KNNClassifierTest.java
+++ b/src/test/java/knnclassifier/KNNClassifierTest.java
@@ -1,0 +1,116 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tletters.knnclassifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Piotr
+ */
+public class KNNClassifierTest
+{
+	
+	public KNNClassifierTest()
+	{
+	}
+	
+	@BeforeClass
+	public static void setUpClass()
+	{
+	}
+	
+	@AfterClass
+	public static void tearDownClass()
+	{
+	}
+	
+	@Before
+	public void setUp()
+	{
+	}
+	
+	@After
+	public void tearDown()
+	{
+	}
+
+
+	/**
+	 * Test of predict method, of class KNNClassifier.
+	 */
+	@Test
+	public void testPredict()
+	{
+		System.out.println("KNNClassifier.predict test");
+		{
+			DistanceMeter<Double> dm = new EuclideanDistanceMeter();
+
+			Classifier< Double, DistanceMeter<Double> > classifier = new KNNClassifier<>(5);
+			Double[] fv = {1.,2.,3.};
+			ArrayList<Double> fvArr = new ArrayList<>( Arrays.asList(fv) );
+			List< Collection<Double> > descriptions = new ArrayList<>();
+			descriptions.add(fvArr);
+
+			Integer[] cl = {1};
+			ArrayList<Integer> classes = new ArrayList<>( Arrays.asList(cl) );
+
+			classifier.fit(descriptions, classes, dm);
+
+			Double[] fv_q = {1.,2.,2.};
+			ArrayList<Double> fv_question = new ArrayList<>( Arrays.asList(fv_q) );
+
+			Integer qclass = classifier.predict(fv_question);
+
+			Integer expResult = 1;
+			assertEquals(expResult, qclass);
+		}
+		
+		{
+			DistanceMeter<Double> dm = new EuclideanDistanceMeter();
+
+			Classifier< Double, DistanceMeter<Double> > classifier = new KNNClassifier<>(2);
+			List< Collection<Double> > descriptions = new ArrayList<>();
+			
+			Double[] fv = {1.,2.,3.};
+			ArrayList<Double> fvArr = new ArrayList<>( Arrays.asList(fv) );
+			descriptions.add(fvArr);
+			Double[] fv2 = {3.,3.,3.};
+			ArrayList<Double> fvArr2 = new ArrayList<>( Arrays.asList(fv2) );
+			descriptions.add(fvArr2);
+			Double[] fv3 = {1.,1.,1.};
+			ArrayList<Double> fvArr3 = new ArrayList<>( Arrays.asList(fv3) );
+			descriptions.add(fvArr3);
+			Double[] fv4 = {0.,1.,0.};
+			ArrayList<Double> fvArr4 = new ArrayList<>( Arrays.asList(fv4) );
+			descriptions.add(fvArr4);
+
+			Integer[] cl = {1,2,3,3};
+			ArrayList<Integer> classes = new ArrayList<>( Arrays.asList(cl) );
+
+			classifier.fit(descriptions, classes, dm);
+
+			Double[] fv_q = {1.,0.,1.};
+			ArrayList<Double> fv_question = new ArrayList<>( Arrays.asList(fv_q) );
+
+			Integer qclass = classifier.predict(fv_question);
+
+			Integer expResult = 3;
+			assertEquals(expResult, qclass);
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
Dodanie podstawowych interfejsów oraz klasyfikatora KNN i prostej przykładowej klasy wyznaczającej odległość euklidesową. 

Przykłady użycia w testach.

Z pytań co do funkcjonalności:

- Nie ma jako takiej obsłógi błędnego użycia - wektory są liczone, dopóki długości pasują, jest założone, że fit(...) zostało wywołane przed predict(...) itp. -czy powinienem coś dodać/zmienić w tym kontekście?

- Napisałem bardzo proste i podstawowe testy - czy powinienem dodać coś jeszcze, czy to już zadanie z innego taska  Test #11 